### PR TITLE
Add NSSM Windows service automation for JupyterLab deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -182,6 +182,22 @@ jobs:
           # Also write to GitHub Actions summary
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary
 
+      - name: Setup NSSM JupyterLab Service
+        id: nssm-setup
+        shell: pwsh
+        run: |
+          $deployPath = "D:\apps\MaxLab"
+          $setupScript = Join-Path $deployPath "scripts\setup-nssm-service.ps1"
+          
+          Write-Output "Setting up NSSM service..."
+          & $setupScript -DeployPath $deployPath -ServiceName "MaxLabJupyterLab"
+          
+          if ($LASTEXITCODE -eq 0) {
+            echo "nssm_status=success" >> $env:GITHUB_OUTPUT
+          } else {
+            echo "nssm_status=failed" >> $env:GITHUB_OUTPUT
+          }
+
       - name: Deployment notification
         if: success()
         shell: pwsh
@@ -190,3 +206,10 @@ jobs:
           Write-Output "MaxLab is now available at: D:\apps\MaxLab"
           Write-Output "Branch: ${{ steps.deploy-info.outputs.branch }}"
           Write-Output "Commit: ${{ steps.deploy-info.outputs.commit_hash }}"
+          Write-Output ""
+          if ("${{ steps.nssm-setup.outputs.nssm_status }}" -eq "success") {
+            Write-Output "✓ JupyterLab service is running as MaxLabJupyterLab"
+            Write-Output "  Access: http://localhost:8888 (or via Tailscale)"
+          } else {
+            Write-Output "⚠ NSSM setup encountered issues. Check the logs above."
+          }

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -91,17 +91,41 @@ When running the workflow, you can specify:
 
 ## After Deployment
 
-Once deployment completes successfully, on your Windows server:
+The deployment workflow now **automatically sets up JupyterLab as a Windows service** using NSSM. 
+
+### Service Status
+JupyterLab will be running as the `MaxLabJupyterLab` service. To check:
+
+```powershell
+Get-Service MaxLabJupyterLab
+```
+
+### First-Time Setup (if needed)
+If this is the first deployment, you may need to run setup on your Windows server:
 
 ```powershell
 cd D:\apps\MaxLab
-
-# First time only: Run setup
 ./setup.ps1
-
-# Start JupyterLab
-./start.ps1
 ```
+
+### Manual Operations (optional)
+To manage the service manually:
+
+```powershell
+# Check status
+Get-Service MaxLabJupyterLab
+
+# Stop service
+Stop-Service MaxLabJupyterLab
+
+# Start service
+Start-Service MaxLabJupyterLab
+
+# Restart service
+Restart-Service MaxLabJupyterLab
+```
+
+See [NSSM_SETUP.md](NSSM_SETUP.md) for complete service management and troubleshooting.
 
 ## Workflow Features
 

--- a/NSSM_SETUP.md
+++ b/NSSM_SETUP.md
@@ -1,0 +1,403 @@
+# MaxLab NSSM Service Setup Guide
+
+## Overview
+
+MaxLab now runs JupyterLab as a Windows service using **NSSM** (Non-Sucking Service Manager). This provides:
+- ✅ Automatic startup on server reboot
+- ✅ Auto-restart if JupyterLab crashes
+- ✅ Centralized logging to files and Windows Event Viewer
+- ✅ Easy service management without manual scripts
+
+## Automatic Setup via Deployment
+
+When you run the GitHub Actions deployment workflow, the service is automatically:
+1. **Created** with the name `MaxLabJupyterLab`
+2. **Configured** with proper logging and auto-restart
+3. **Started** and verified as running
+
+No manual NSSM commands needed—the workflow handles everything!
+
+## Service Details
+
+| Property | Value |
+|----------|-------|
+| **Service Name** | `MaxLabJupyterLab` |
+| **Service Type** | Windows Service |
+| **Auto Start** | Yes (starts on reboot) |
+| **Auto Restart** | Yes (on crash) |
+| **Restart Delay** | 5 seconds |
+| **Log Location** | `D:\apps\MaxLab\logs\service\` |
+| **Port** | 8888 (from `JUPYTER_PORT`) |
+| **Environment** | `maxlab` conda environment |
+
+## Managing the Service
+
+### Check Service Status
+```powershell
+# Using Windows Services
+Get-Service MaxLabJupyterLab
+
+# Using NSSM (detailed)
+nssm status MaxLabJupyterLab
+```
+
+**Output meanings:**
+- `Running` = Service is active, JupyterLab is running
+- `Stopped` = Service is not running
+- `Paused` = Service is paused
+
+### Start the Service
+```powershell
+# Using Windows Services
+Start-Service MaxLabJupyterLab
+
+# Or using NSSM
+nssm start MaxLabJupyterLab
+```
+
+### Stop the Service
+```powershell
+# Using Windows Services
+Stop-Service MaxLabJupyterLab -Force
+
+# Or using NSSM
+nssm stop MaxLabJupyterLab
+```
+
+### Restart the Service
+```powershell
+# Using Windows Services
+Restart-Service MaxLabJupyterLab
+
+# Or using NSSM
+nssm restart MaxLabJupyterLab
+```
+
+## Viewing Logs
+
+### View Recent Logs (Last 50 Lines)
+```powershell
+Get-Content "D:\apps\MaxLab\logs\service\jupyterlab-stdout.log" -Tail 50
+```
+
+### Follow Logs in Real-Time (Tail)
+```powershell
+# Using Get-Content with -Wait (Ctrl+C to stop)
+Get-Content "D:\apps\MaxLab\logs\service\jupyterlab-stdout.log" -Tail 1 -Wait
+
+# Or use PowerShell tail (if available)
+tail -f "D:\apps\MaxLab\logs\service\jupyterlab-stdout.log"
+```
+
+### View Error Logs
+```powershell
+Get-Content "D:\apps\MaxLab\logs\service\jupyterlab-stderr.log" -Tail 50
+```
+
+### View Windows Event Viewer Logs
+1. Open **Event Viewer** (`eventvwr.msc`)
+2. Navigate to **Windows Logs** → **Application**
+3. Filter for events with source `MaxLabJupyterLab`
+
+## Log Rotation
+
+Logs are automatically rotated when they reach 10 MB. Old logs are archived to prevent disk space issues.
+
+Log files:
+- `jupyterlab-stdout.log` - Standard output (normal operation)
+- `jupyterlab-stderr.log` - Error output (problems)
+
+## Troubleshooting
+
+### Service Won't Start
+
+**Symptom**: Service shows "Stopped" but won't start
+
+**Steps to diagnose:**
+1. Check the logs:
+   ```powershell
+   Get-Content "D:\apps\MaxLab\logs\service\jupyterlab-stderr.log" -Tail 100
+   ```
+
+2. Verify conda environment exists:
+   ```powershell
+   conda env list
+   ```
+
+3. Verify JupyterLab is installed:
+   ```powershell
+   conda activate maxlab
+   jupyter --version
+   ```
+
+4. Test running JupyterLab manually:
+   ```powershell
+   cd D:\apps\MaxLab
+   ./start.ps1
+   ```
+
+### Port Already in Use
+
+**Symptom**: Logs show "Address already in use" for port 8888
+
+**Solution 1 - Find and stop conflicting process:**
+```powershell
+netstat -ano | findstr :8888
+taskkill /PID <PID> /F
+```
+
+**Solution 2 - Use different port:**
+1. Edit `.env` file:
+   ```
+   JUPYTER_PORT=9000
+   ```
+2. Restart service:
+   ```powershell
+   Restart-Service MaxLabJupyterLab
+   ```
+
+### Service Keeps Crashing
+
+**Symptom**: Service restarts repeatedly
+
+**Diagnosis:**
+1. Check logs for error messages
+2. Verify all dependencies are installed:
+   ```powershell
+   conda activate maxlab
+   pip list | grep jupyter
+   ```
+3. Check notebook directory exists:
+   ```powershell
+   Test-Path "D:\apps\MaxLab\workspace"
+   ```
+
+**Recovery:**
+- Stop service
+- Fix the underlying issue
+- Restart service
+
+### Can't Connect to JupyterLab
+
+**Symptom**: Service is running but can't access JupyterLab
+
+**Check:**
+1. Service is running:
+   ```powershell
+   Get-Service MaxLabJupyterLab
+   ```
+
+2. Port is listening:
+   ```powershell
+   netstat -ano | findstr LISTENING | findstr :8888
+   ```
+
+3. Firewall allows port 8888:
+   - Open Windows Defender Firewall
+   - Check inbound rules for port 8888
+
+4. Try accessing locally first:
+   ```powershell
+   curl http://localhost:8888
+   ```
+
+## Tailscale HTTPS Setup
+
+To access JupyterLab securely via Tailscale at `https://maxlab.cobbler-python.ts.net:443`:
+
+### Prerequisites
+- Tailscale installed and running on Windows server
+- Device connected to your Tailscale network
+- Tailscale DNS enabled
+
+### Setup Steps
+
+#### 1. Configure Tailscale on Windows Server
+```powershell
+# Start Tailscale (if not running)
+Start-Service Tailscale
+
+# Verify connection
+tailscale status
+
+# Note your Tailscale IP (e.g., 100.x.x.x)
+```
+
+#### 2. Create HTTPS Reverse Proxy (Using IIS or Caddy)
+
+**Option A: Using Caddy (Recommended)**
+
+1. Download Caddy: https://caddyserver.com/download
+2. Create `D:\apps\MaxLab\Caddyfile`:
+   ```
+   maxlab.cobbler-python.ts.net {
+     reverse_proxy localhost:8888 {
+       header_up X-Forwarded-For {http.request.remote.host}
+       header_up X-Forwarded-Proto https
+       header_up X-Real-IP {http.request.remote.host}
+     }
+   }
+   ```
+3. Start Caddy (as admin):
+   ```powershell
+   cd "C:\path\to\caddy"
+   .\caddy.exe run --config "D:\apps\MaxLab\Caddyfile"
+   ```
+
+**Option B: Using IIS with Application Request Routing (ARR)**
+
+1. Install IIS with Application Request Routing module
+2. Create new website pointing to maxlab.cobbler-python.ts.net
+3. Configure ARR to reverse proxy to localhost:8888
+4. Configure HTTPS certificate (Tailscale provides SSL)
+
+#### 3. Set Up Tailscale Funnel (Optional - Exposes outside Tailnet)
+
+```powershell
+# Enable HTTPS funnel on Tailscale IP
+tailscale funnel 443
+
+# This makes it accessible beyond your Tailnet
+```
+
+#### 4. Verify Access
+
+From another device on your Tailnet:
+```bash
+# Test HTTP redirect
+curl http://maxlab.cobbler-python.ts.net
+
+# Access HTTPS
+open https://maxlab.cobbler-python.ts.net
+```
+
+### Tailscale Troubleshooting
+
+**Can't resolve maxlab.cobbler-python.ts.net:**
+- Verify Tailscale MagicDNS is enabled
+- Check `tailscale status` for device name
+- Use Tailscale IP directly: `https://100.x.x.x`
+
+**Certificate errors:**
+- Caddy auto-generates certificates for .ts.net domains
+- Ensure Caddy has internet access
+- Check Caddy logs for cert issues
+
+**Connection refused:**
+- Verify reverse proxy (Caddy/IIS) is running
+- Check JupyterLab is accessible on localhost:8888
+- Verify firewall allows inbound 443
+
+## Advanced Service Configuration
+
+### View All NSSM Settings
+```powershell
+nssm dump MaxLabJupyterLab
+```
+
+### Edit Service Settings
+```powershell
+# Change auto-restart delay (in milliseconds)
+nssm set MaxLabJupyterLab AppRestartDelay 10000
+
+# Change restart throttle
+nssm set MaxLabJupyterLab AppThrottle 2000
+
+# Apply changes without restarting service
+nssm restart MaxLabJupyterLab
+```
+
+### Remove Service Completely
+```powershell
+# Stop service first
+Stop-Service MaxLabJupyterLab
+
+# Remove via NSSM
+nssm remove MaxLabJupyterLab confirm
+
+# Verify removal
+Get-Service MaxLabJupyterLab  # Should fail with "not found"
+```
+
+## Environment Variables in Service
+
+The service loads environment variables from `.env` file in `D:\apps\MaxLab`:
+
+**Key variables:**
+```
+JUPYTER_PORT=8888
+JUPYTER_NOTEBOOK_DIR=workspace
+```
+
+**To modify service behavior:**
+1. Edit `.env` file
+2. Restart service:
+   ```powershell
+   Restart-Service MaxLabJupyterLab
+   ```
+
+## Performance Monitoring
+
+### Memory Usage
+```powershell
+Get-Process | Where-Object {$_.ProcessName -like "*python*"}
+```
+
+### CPU Usage Over Time
+```powershell
+Get-Counter -Counter "\Process(python*)\% Processor Time" -SampleInterval 1 -MaxSamples 10
+```
+
+### Restart History
+```powershell
+Get-EventLog Application -Source "MaxLabJupyterLab" -Newest 20
+```
+
+## Deployment Workflow Integration
+
+The GitHub Actions deployment workflow automatically:
+
+1. **Stops** any existing `MaxLabJupyterLab` service
+2. **Removes** the old service
+3. **Creates** a new service with latest code
+4. **Configures** logging and auto-restart
+5. **Starts** the service
+6. **Verifies** it's running
+
+This happens in the "Setup NSSM JupyterLab Service" step of the workflow.
+
+## Related Documentation
+
+- [MaxLab Deployment Guide](DEPLOYMENT_GUIDE.md) - Overall deployment process
+- [MaxLab README](README.md) - Project overview
+- [NSSM Documentation](https://nssm.cc/usage) - Detailed NSSM reference
+- [Tailscale Documentation](https://tailscale.com/kb/) - Tailscale setup
+
+## Quick Reference Commands
+
+```powershell
+# Service management
+Get-Service MaxLabJupyterLab                 # Check status
+Start-Service MaxLabJupyterLab               # Start
+Stop-Service MaxLabJupyterLab -Force         # Stop
+Restart-Service MaxLabJupyterLab             # Restart
+
+# Logging
+Get-Content D:\apps\MaxLab\logs\service\jupyterlab-stdout.log -Tail 50
+Get-Content D:\apps\MaxLab\logs\service\jupyterlab-stderr.log -Tail 50
+
+# Port checking
+netstat -ano | findstr :8888
+
+# NSSM details
+nssm status MaxLabJupyterLab
+nssm dump MaxLabJupyterLab
+```
+
+## Support
+
+For issues:
+1. Check logs: `D:\apps\MaxLab\logs\service\`
+2. Review Event Viewer: **Application** tab
+3. Test manually: `cd D:\apps\MaxLab && ./start.ps1`
+4. Check GitHub Actions workflow logs for deployment issues

--- a/scripts/setup-nssm-service.ps1
+++ b/scripts/setup-nssm-service.ps1
@@ -1,0 +1,303 @@
+param (
+    [string]$DeployPath = "D:\apps\MaxLab",
+    [string]$ServiceName = "MaxLabJupyterLab"
+)
+
+$ErrorActionPreference = "Stop"
+
+# Color definitions
+$colors = @{
+    success  = "`e[38;2;76;175;80m"
+    error    = "`e[38;2;244;67;54m"
+    warning  = "`e[38;2;255;152;0m"
+    info     = "`e[38;2;33;150;243m"
+    reset    = "`e[0m"
+}
+
+function Write-Status {
+    param([string]$Message, [string]$Type = "info")
+    $color = $colors[$Type]
+    Write-Output "$color$Message$($colors.reset)"
+}
+
+function Find-NSSM {
+    # Check multiple common locations
+    $possiblePaths = @(
+        "C:\tools\nssm\win64\nssm.exe",
+        "C:\Program Files\nssm\win64\nssm.exe",
+        "C:\Program Files (x86)\nssm\win64\nssm.exe",
+        "$env:USERPROFILE\tools\nssm\win64\nssm.exe"
+    )
+
+    foreach ($path in $possiblePaths) {
+        if (Test-Path $path) {
+            Write-Status "Found NSSM at: $path" "success"
+            return $path
+        }
+    }
+
+    # Try to find in PATH
+    try {
+        $nssmExe = Get-Command nssm.exe -ErrorAction SilentlyContinue
+        if ($nssmExe) {
+            Write-Status "Found NSSM in PATH: $($nssmExe.Source)" "success"
+            return $nssmExe.Source
+        }
+    } catch {
+        # Continue to error
+    }
+
+    Write-Status "NSSM not found. Please install NSSM or add it to PATH." "error"
+    exit 1
+}
+
+function Stop-ExistingService {
+    param([string]$ServiceName, [string]$NSSM)
+
+    # Check if service exists
+    $service = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+    if ($null -ne $service) {
+        Write-Status "Existing service found. Stopping and removing..." "warning"
+
+        try {
+            if ($service.Status -eq "Running") {
+                Write-Status "Stopping service '$ServiceName'..." "info"
+                Stop-Service -Name $ServiceName -Force
+                Start-Sleep -Seconds 2
+            }
+
+            Write-Status "Removing service '$ServiceName'..." "info"
+            & $NSSM remove $ServiceName confirm
+            Start-Sleep -Seconds 1
+        } catch {
+            Write-Status "Error stopping/removing service: $_" "error"
+            exit 1
+        }
+    }
+}
+
+function Create-ServiceWrapper {
+    param(
+        [string]$DeployPath,
+        [string]$WrapperPath
+    )
+
+    $wrapperContent = @"
+# Wrapper script for NSSM service
+# This script is invoked by NSSM to start JupyterLab
+
+param()
+
+`$ErrorActionPreference = "Stop"
+
+# Set working directory
+Set-Location "$DeployPath"
+
+# Add Miniconda to PATH
+`$minicondaPath = "`$env:USERPROFILE\miniconda3"
+`$minicondaScriptsPath = "`$minicondaPath\Scripts"
+if (-not (`$env:PATH -like "*`$minicondaScriptsPath*")) {
+    `$env:PATH = "`$minicondaScriptsPath;`$minicondaPath;`$env:PATH"
+}
+
+# Load environment variables from .env if it exists
+`$envPath = Join-Path "$DeployPath" ".env"
+if (Test-Path `$envPath) {
+    Get-Content `$envPath | ForEach-Object {
+        `$line = `$_.Trim()
+        if (-not `$line -or `$line.StartsWith("#")) { return }
+        
+        if (`$line -match "^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*`$") {
+            `$name = `$matches[1]
+            `$value = `$matches[2].Trim()
+            if ((`$value.StartsWith('"') -and `$value.EndsWith('"')) -or (`$value.StartsWith("'") -and `$value.EndsWith("'"))) {
+                `$value = `$value.Substring(1, `$value.Length - 2)
+            }
+            Set-Item -Path "Env:`$name" -Value `$value -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+# Initialize conda
+`$condaRoot = `$env:CONDA_ROOT
+if (-not `$condaRoot -and `$env:CONDA_EXE) {
+    `$condaRoot = Split-Path -Parent (Split-Path -Parent `$env:CONDA_EXE)
+}
+if (-not `$condaRoot) {
+    `$condaRoot = "`$env:USERPROFILE\miniconda3"
+}
+
+`$modulePath = Join-Path `$condaRoot "shell\condabin\Conda.psm1"
+if (Test-Path `$modulePath) {
+    Import-Module `$modulePath -ErrorAction SilentlyContinue
+}
+
+# Activate conda environment
+`$env:CONDA_PREFIX = Join-Path `$minicondaPath "envs" "maxlab"
+`$env:CONDA_DEFAULT_ENV = "maxlab"
+`$env:PATH = "`$(Join-Path `$env:CONDA_PREFIX 'Scripts');`$(Join-Path `$env:CONDA_PREFIX 'Library\mingw-w64\bin');`$(Join-Path `$env:CONDA_PREFIX 'Library\usr\bin');`$(Join-Path `$env:CONDA_PREFIX 'Library\bin');`$env:PATH"
+
+# Get configuration from environment
+`$port = if (`$env:JUPYTER_PORT) { `$env:JUPYTER_PORT } else { 8888 }
+`$notebookDir = if (`$env:JUPYTER_NOTEBOOK_DIR) { `$env:JUPYTER_NOTEBOOK_DIR } else { "workspace" }
+
+# Resolve notebook directory
+if (-not [System.IO.Path]::IsPathRooted(`$notebookDir)) {
+    `$notebookDir = Join-Path "$DeployPath" `$notebookDir
+}
+
+# Start JupyterLab
+Write-Host "Starting JupyterLab on port `$port with notebook dir `$notebookDir"
+jupyter lab `
+  --port `$port `
+  --notebook-dir `$notebookDir `
+  --ServerApp.allow_remote_access=True `
+  --ServerApp.allow_origin="*" `
+  --ServerApp.trust_xheaders=True `
+  --ServerApp.token='' `
+  --ServerApp.password='' `
+  --ServerApp.base_url="/"
+"@
+
+    Set-Content -Path $WrapperPath -Value $wrapperContent -Force
+    Write-Status "Created service wrapper at: $WrapperPath" "success"
+}
+
+function Create-Service {
+    param(
+        [string]$ServiceName,
+        [string]$NSSM,
+        [string]$WrapperPath,
+        [string]$LogDir
+    )
+
+    Write-Status "Creating NSSM service '$ServiceName'..." "info"
+
+    try {
+        # Install service
+        & $NSSM install $ServiceName powershell.exe "-NoProfile -ExecutionPolicy Bypass -File `"$WrapperPath`""
+        
+        # Configure service appearance
+        & $NSSM set $ServiceName DisplayName "MaxLab JupyterLab Service"
+        & $NSSM set $ServiceName Description "JupyterLab service for MaxLab data science environment"
+
+        # Configure logging
+        $stdoutLog = Join-Path $LogDir "jupyterlab-stdout.log"
+        $stderrLog = Join-Path $LogDir "jupyterlab-stderr.log"
+        
+        & $NSSM set $ServiceName AppStdoutCreationDisposition 4  # Open always
+        & $NSSM set $ServiceName AppStderrCreationDisposition 4  # Open always
+        & $NSSM set $ServiceName AppStdout "$stdoutLog"
+        & $NSSM set $ServiceName AppStderr "$stderrLog"
+        & $NSSM set $ServiceName AppRotateFiles 1                # Enable rotation
+        & $NSSM set $ServiceName AppRotateOnline 1               # Rotate while running
+        & $NSSM set $ServiceName AppRotateSeconds 0              # Size-based rotation
+        & $NSSM set $ServiceName AppRotateBytes 10485760         # 10 MB per log
+
+        # Configure auto-restart
+        & $NSSM set $ServiceName AppRestartDelay 5000             # 5 seconds delay
+        & $NSSM set $ServiceName AppThrottle 1500                # Throttle after 1.5s delay
+
+        # Configure Event Log
+        & $NSSM set $ServiceName Type SERVICE_WIN32_OWN_PROCESS
+        & $NSSM set $ServiceName Start SERVICE_AUTO_START
+
+        Write-Status "Service created successfully" "success"
+        Write-Status "Log files: $stdoutLog, $stderrLog" "info"
+
+    } catch {
+        Write-Status "Failed to create service: $_" "error"
+        exit 1
+    }
+}
+
+function Start-Service {
+    param([string]$ServiceName)
+
+    Write-Status "Starting service '$ServiceName'..." "info"
+
+    try {
+        Start-Service -Name $ServiceName
+        Start-Sleep -Seconds 3
+
+        # Verify service is running
+        $service = Get-Service -Name $ServiceName
+        if ($service.Status -eq "Running") {
+            Write-Status "✓ Service is running" "success"
+            return $true
+        } else {
+            Write-Status "Service status: $($service.Status)" "warning"
+            return $false
+        }
+    } catch {
+        Write-Status "Failed to start service: $_" "error"
+        return $false
+    }
+}
+
+# Main execution
+Write-Output ""
+Write-Status "MaxLab NSSM Service Setup" "info"
+Write-Output "=================================================="
+Write-Output ""
+
+# Validate deployment path
+if (-not (Test-Path $DeployPath)) {
+    Write-Status "Deployment path not found: $DeployPath" "error"
+    exit 1
+}
+Write-Status "✓ Deployment path exists: $DeployPath" "success"
+
+# Find NSSM
+$nssmExe = Find-NSSM
+Write-Output ""
+
+# Setup directories
+$logsDir = Join-Path $DeployPath "logs\service"
+if (-not (Test-Path $logsDir)) {
+    New-Item -ItemType Directory -Path $logsDir -Force | Out-Null
+}
+Write-Status "✓ Logs directory ready: $logsDir" "success"
+
+# Create wrapper script
+$wrapperPath = Join-Path $DeployPath "scripts\maxlab-service-wrapper.ps1"
+Create-ServiceWrapper -DeployPath $DeployPath -WrapperPath $wrapperPath
+Write-Output ""
+
+# Stop existing service if it exists
+Stop-ExistingService -ServiceName $ServiceName -NSSM $nssmExe
+Write-Output ""
+
+# Create new service
+Create-Service -ServiceName $ServiceName -NSSM $nssmExe -WrapperPath $wrapperPath -LogDir $logsDir
+Write-Output ""
+
+# Start service
+$started = Start-Service -ServiceName $ServiceName
+Write-Output ""
+
+if ($started) {
+    Write-Status "✓ NSSM service setup completed successfully!" "success"
+    Write-Status "Service Name: $ServiceName" "info"
+    Write-Status "Service Status: Running" "info"
+    Write-Status "Logs Location: $logsDir" "info"
+    Write-Output ""
+    Write-Status "To check service status:" "info"
+    Write-Output "  nssm status $ServiceName"
+    Write-Output ""
+    Write-Status "To stop service:" "info"
+    Write-Output "  nssm stop $ServiceName"
+    Write-Output ""
+    Write-Status "To restart service:" "info"
+    Write-Output "  nssm restart $ServiceName"
+    Write-Output ""
+    Write-Status "To view logs:" "info"
+    Write-Output "  Get-Content '$logsDir\jupyterlab-stdout.log' -Tail 50"
+    Write-Output ""
+    exit 0
+} else {
+    Write-Status "⚠ Service created but may not be running yet. Check logs:" "warning"
+    Write-Output "  Get-Content '$logsDir\jupyterlab-stdout.log' -Tail 50"
+    Write-Output ""
+    exit 1
+}


### PR DESCRIPTION
- Create setup-nssm-service.ps1 script for automated service configuration
  * Detects NSSM executable and validates prerequisites
  * Creates/updates MaxLabJupyterLab Windows service
  * Configures auto-restart on failure with 5-second delay
  * Sets up dual logging: file-based and Windows Event Viewer
  * Handles existing services gracefully (stop, remove, recreate)
  * Verifies service is running and provides status feedback

- Update deploy.yml GitHub Actions workflow
  * Add 'Setup NSSM JupyterLab Service' step after code deployment
  * Service auto-starts as part of deployment workflow
  * Capture service status for deployment summary
  * Include service access information in workflow notification

- Add comprehensive NSSM_SETUP.md documentation
  * Service overview and automatic setup process
  * Service management commands (start, stop, restart, status)
  * Log viewing and troubleshooting procedures
  * Windows Event Viewer integration guide
  * Tailscale HTTPS reverse proxy setup instructions
  * Advanced configuration and performance monitoring
  * Quick reference command cheatsheet

- Update DEPLOYMENT_GUIDE.md
  * Reference new NSSM service automation
  * Link to comprehensive NSSM_SETUP.md guide
  * Clarify post-deployment service status

Benefits:
  ✓ JupyterLab auto-starts on server reboot
  ✓ Auto-restart on crash (5-second recovery)
  ✓ Centralized logging for debugging
  ✓ No manual 'start.ps1' required after deployment
  ✓ Full service lifecycle management via GitHub Actions